### PR TITLE
Add support for grub2.

### DIFF
--- a/arch/x86_64/boot/Makefile
+++ b/arch/x86_64/boot/Makefile
@@ -66,13 +66,14 @@ FDINITRD = $(shell echo $(CONFIG_INIT_TASK_IMAGE))
 # Set this if you want to pass append arguments to the isoimage kernel
 FDARGS = $(KERNEL_ARGS) init_argv=$(CONFIG_INIT_TASK_ARGS) init_envp=$(CONFIG_INIT_TASK_ENVS)
 FDARGS_GRUB = $(KERNEL_ARGS) init_argv=\"$(CONFIG_INIT_TASK_ARGS)\" init_envp=\"$(CONFIG_INIT_TASK_ENVS)\"
+FDARGS_GRUB2 = $(KERNEL_ARGS) init_argv=$(CONFIG_INIT_TASK_ARGS) init_envp=$(CONFIG_INIT_TASK_ENVS)
 
 # Initial grub2 modules to be loaded.
 GRUB2_INIT_MODS = $(shell echo $(CONFIG_GRUB2_MODS))
 
 image_cmdline = default lwk $(FDARGS) $(if $(FDINITRD),initrd=initrd.img,)
 gimage_cmdline = default 0\ntimeout 5\n\ntitle Kitten\nroot (cd)\nkernel /boot/lwk ro $(FDARGS_GRUB)\n$(if $(FDINITRD),initrd /boot/initrd.img,)
-gimage2_cmdline = set default=0\nset timeout=5\n\nmenuentry Kitten {\n\tlinux /boot/lwk ro $(FDARGS_GRUB)\n $(if $(FDINITRD),\tinitrd /boot/initrd.img,)\n}
+gimage2_cmdline = set default=0\nset timeout=5\n\nmenuentry Kitten {\n\tlinux /boot/lwk ro $(FDARGS_GRUB2)\n $(if $(FDINITRD),\tinitrd /boot/initrd.img,)\n}
 
 # This requires being root or having syslinux 2.02 or higher installed
 isoimage: $(BOOTIMAGE)
@@ -122,7 +123,7 @@ ifeq ($(CONFIG_SYSLINUX_BOOTLOADER),y)
 	fi
 	rm -rf $(obj)/isoimage
 else
-	@ver=`grub-install -v | sed "s,.* \([0-9]\).[0-9].*,\1,"`; \
+	@ver=`grub-install --version | sed "s,.* \([0-9]\).[0-9].*,\1,"`; \
 	platform=pc; \
 	model=`uname -m`; \
 	if [ "$$model" = "i486" -o "$$model" = "i586" -o "$$model" = "i686" -o $$ver -ne 0 ]; then \
@@ -147,6 +148,13 @@ else
 			cp /usr/lib/grub/$${model}-$$platform/stage2_eltorito $(obj)/isoimage/boot/grub; \
 			mkisofs -J -R -o $(obj)/image.iso -b boot/grub/stage2_eltorito \
 				-c boot.cat -no-emul-boot -boot-load-size 4 -boot-info-table $(obj)/isoimage; \
+		elif [ $$ver -eq 2 ]; then \
+			modules="$(cat $(bootprep)/partmap.lst) $(GRUB2_INIT_MODS)"; \
+			(for i in $$modules; do \
+				echo "insmod $$i";   \
+			done; \
+			echo '$(gimage2_cmdline)') > $(obj)/isoimage/boot/grub/grub.cfg; \
+		  grub-mkrescue -o $(obj)/image.iso $(obj)/isoimage; \
 		else \
 			bootprep=$(obj)/bootprep/boot/grub/$$model-$$platform; \
 			p_dir=/usr/lib/grub/$$model-$$platform; \


### PR DESCRIPTION
"make isoimage" with grub set in .config (everything else default) was not working on Ubuntu 16.04 for me (it had previously worked on centos7 for me). The problem was in installing grub and making the iso in /arch/x86_64/boot/Makefile. I think the difference is that Ubuntu uses grub2 while centos uses grub1 or at least older versions of grub commands.

I tried to do this portably, but I don't have another OS readily available right now to test it. Maybe someone can try it out on their standard build environment?

Specifically:
- Change grub version test to "grub-install --version" (-v is "version" on grub1 and "verbose" on grub2, --version should work on both)
- I add a new section for version=2 (I'm not sure what version "0" and the "else" we're assuming). I use grub-mkrescue to build image.iso for grub2 as instructed [here.](https://www.gnu.org/software/grub/manual/html_node/Making-a-GRUB-bootable-CD_002dROM.html)
- Grub2 seems to quote things differently (or maybe it's something else). Either way, my application in kitten was seeing some extra quotes in argv so I removed them from gimage2_cmdline. I'm not sure if this is the right thing to do (quoting rules seem to vary a lot).

Testing:
- Tested on Ubntu 16.04 with default .config (except for change to grub from syslinux)
- Tested using a hello_world that prints argv and envp
- Not tested with grub1 or other distros. Not sure about how portable the solution is. Especially the argument quoting issue.
