### PR TITLE
Add support for cpio based initrd images

### DIFF
--- a/arch/arm64/mm/init.c
+++ b/arch/arm64/mm/init.c
@@ -417,9 +417,6 @@ __move_initrd(size_t kmem_size)
 	/* Update initrd_start and initrd_end to their new values */
 	initrd_start = new_initrd_start;
 	initrd_end   = new_initrd_end;
-
-	/* Assume the initrd image is the init_task ELF executable */
-	init_elf_image = initrd_start;
 }
 
 

--- a/arch/x86_64/mm/init.c
+++ b/arch/x86_64/mm/init.c
@@ -377,8 +377,5 @@ arch_memsys_init(size_t kmem_size)
 	/* Update initrd_start and initrd_end to their new values */
 	initrd_start = new_initrd_start;
 	initrd_end   = new_initrd_end;
-
-	/* Assume the initrd image is the init_task ELF executable */
-	init_elf_image = initrd_start;
 }
 

--- a/include/arch-generic/fcntl.h
+++ b/include/arch-generic/fcntl.h
@@ -57,6 +57,10 @@
 
 #define AT_FDCWD (-100)
 
+#define AT_SYMLINK_FOLLOW	0x400   /* Follow symbolic links.  */
+#define AT_NO_AUTOMOUNT		0x800	/* Suppress terminal automount traversal */
+#define AT_EMPTY_PATH		0x1000	/* Allow empty relative pathname */
+
 #define F_DUPFD		0	/* dup */
 #define F_GETFD		1	/* get close_on_exec */
 #define F_SETFD		2	/* set/clear close_on_exec */

--- a/include/arch-x86_64/proto.h
+++ b/include/arch-x86_64/proto.h
@@ -32,7 +32,7 @@ extern unsigned long __phys_addr(unsigned long virt_addr);
 
 void __init interrupts_init(void);
 
-extern paddr_t initrd_start, initrd_end;
+
 
 
 /** Low-level interrupt handler type */

--- a/include/arch-x86_64/unistd.h
+++ b/include/arch-x86_64/unistd.h
@@ -582,7 +582,7 @@ __SYSCALL(__NR_fchownat, syscall_not_implemented)
 #define __NR_futimesat		261
 __SYSCALL(__NR_futimesat, syscall_not_implemented)
 #define __NR_newfstatat		262
-__SYSCALL(__NR_newfstatat, syscall_not_implemented)
+__SYSCALL(__NR_newfstatat, newfstatat)
 #define __NR_unlinkat		263
 __SYSCALL(__NR_unlinkat, syscall_not_implemented)
 #define __NR_renameat		264

--- a/include/lwk/init.h
+++ b/include/lwk/init.h
@@ -81,8 +81,12 @@ extern void setup_arch(void);
 
 extern void start_kernel(void);
 
+int setup_userspace(paddr_t initrd_start, paddr_t initrd_end);
+
+extern paddr_t initrd_start, initrd_end;
+
 extern int create_init_task(void);
-extern paddr_t init_elf_image;
+//extern paddr_t init_elf_image;
 
 #endif /* !__ASSEMBLY__ */
   

--- a/include/lwk/initrd.h
+++ b/include/lwk/initrd.h
@@ -1,0 +1,15 @@
+#ifndef _LWK_INITRD_H
+#define _LWK_INITRD_H
+
+int
+initrd_is_initrd(paddr_t initrd_start,
+                 paddr_t initrd_end);
+
+
+uint8_t * 
+unpack_initrd(paddr_t initrd_start,
+              paddr_t initrd_end);
+
+
+
+#endif

--- a/include/lwk/macros.h
+++ b/include/lwk/macros.h
@@ -3,6 +3,7 @@
 
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
 #define ALIGN(x,a) (((x)+(a)-1)&~((a)-1))
+#define IS_ALIGNED(x, a) ((x % a) == 0)
 #define DIV_ROUND_UP(n,d) (((n) + (d) - 1) / (d))
 
 /*

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -23,6 +23,7 @@ obj-y := \
 	waitq.o \
 	timer.o \
 	init_task.o \
+	initrd.o \
 	kfs.o \
 	interrupt.o \
 	semaphore.o \

--- a/kernel/init_task.c
+++ b/kernel/init_task.c
@@ -5,6 +5,7 @@
 #include <lwk/elf.h>
 #include <lwk/kfs.h>
 #include <lwk/sched.h>
+#include <lwk/initrd.h>
 
 /**
  * Maximum number of arguments and environment variables that may
@@ -23,7 +24,7 @@
 /**
  * The init_task ELF executable.
  */
-paddr_t init_elf_image;
+static uint8_t * init_elf_image;
 
 /**
  * Amount of memory to reserve for the init_task's heap.
@@ -69,6 +70,7 @@ __initrd_is_elf(paddr_t initrd_start,
 
 
 
+
 /**
  *  Set the up userspace environment using INITRD data
  */
@@ -78,11 +80,22 @@ setup_userspace(paddr_t initrd_start,
 {
 	if (__initrd_is_elf(initrd_start, initrd_end)) {
 		printk("INITRD: ELF executable\n");
-		init_elf_image = initrd_start;
+		init_elf_image = __va(initrd_start);
+	} else if (initrd_is_initrd(initrd_start, initrd_end)) {
+		printk("INITRD: INITRD archive\n");
+		init_elf_image = unpack_initrd(initrd_start, initrd_end); 
+
 	} else {
 		printk("Error: Invalid INITRD format\n");
 		return -EINVAL;
 	}
+
+	if (init_elf_image == NULL) {
+		printk("Error: Invalid INITRD\n");
+		return -EINVAL;
+	}
+
+	return 0;
 }
 
 
@@ -110,7 +123,7 @@ create_init_task(void)
 	/* This initializes start_state aspace_id, entry_point, and stack_ptr */
 	status =
 	elf_load(
-		__va(init_elf_image),
+		init_elf_image,
 		start_state.task_name,
 		INIT_ASPACE_ID,
 		PAGE_SIZE,

--- a/kernel/initrd.c
+++ b/kernel/initrd.c
@@ -1,0 +1,271 @@
+#include <lwk/kfs.h>
+#include <lwk/pmem.h>
+#include <arch/uaccess.h>
+#include <lwk/ctype.h>
+#include <lwk/stat.h>
+
+
+#define MAX_FILE_SIZE (256 * 1024 * 1024)   /* 256 MB for now... */
+
+struct initrd_file_info {
+	uint8_t * data;
+
+	struct mutex fop_mutex; /* We probably want this... */
+};
+
+
+static uint8_t cpio_magic_newc[6] = {'0', '7', '0', '7', '0', '1'};
+static uint8_t cpio_magic_crc[6]  = {'0', '7', '0', '7', '0', '2'};
+
+struct cpio_header {
+	uint8_t c_magic[6];
+	uint8_t c_ino[8];
+	uint8_t c_mode[8];
+	uint8_t c_uid[8];
+	uint8_t c_gid[8];
+	uint8_t c_nlink[8];
+	uint8_t c_mtime[8];
+	uint8_t c_filesize[8];
+	uint8_t c_maj[8];
+	uint8_t c_min[8];
+	uint8_t c_rmaj[8];
+	uint8_t c_rmin[8];
+	uint8_t c_namesize[8];
+	uint8_t c_chksum[8];
+
+} __attribute__((packed));
+
+
+
+
+#define dbg(fmt,args...)
+//#define dbg _KDBG
+
+#define PRIV_DATA(x) ((struct initrd_file_info *) x)
+
+int 
+initrd_is_initrd(paddr_t initrd_start, 
+                 paddr_t initrd_end)
+{
+
+	if (initrd_end - initrd_start <= sizeof(cpio_magic_newc)) {
+		return 0;
+	} 
+
+	if (memcmp(__va(initrd_start), cpio_magic_newc, sizeof(cpio_magic_newc)) == 0) {
+		return 1;
+	}
+
+	return 0;
+}
+
+
+
+
+static int initrd_open(struct inode * inode, struct file * file)
+{
+	file->pos = 0;
+	file->private_data = inode->i_private;
+	return 0;
+}
+
+static ssize_t
+initrd_read(struct file * file,
+            char        * buf,
+            size_t        len,
+            loff_t      * off)
+{
+	struct initrd_file_info * priv = file->private_data;
+
+	len = file->pos + len > file->inode->size ?
+	      file->inode->size - file->pos : len;
+
+	if ( copy_to_user(buf, priv->data + file->pos, len) ) {
+		return -EFAULT;
+	}
+
+	file->pos += len;
+
+	return len;
+}
+
+static ssize_t
+initrd_write(struct file * file,
+             const char  * buf,
+             size_t        len,
+             loff_t      * off)
+{
+	return -EPERM;
+}
+
+static ssize_t
+initrd_lseek(struct file * file,
+             off_t         offset,
+             int           whence)
+{
+	struct initrd_file_info * priv = file->private_data;
+
+	switch ( whence ) {
+	    case 0: /* SEEK_SET */
+		if ( offset > MAX_FILE_SIZE ) 
+			return -EINVAL; 
+		file->pos = offset;
+		break;
+
+	     case 1: /*  SEEK_CUR */
+		if ( file->pos + offset > MAX_FILE_SIZE ) 
+			return -EINVAL; 
+		file->pos += offset;
+		break;
+
+	     case 2: /* SEEK_END */
+		file->pos = file->inode->size;
+		break;
+
+	     default:
+		return -EINVAL;
+	}
+	return file->pos;
+}
+
+static int 
+initrd_ioctl(struct file * file,
+                int           request,
+                uaddr_t       addr	
+)
+{
+	return -EINVAL;
+}
+
+static int create(struct inode *inode, int mode)
+{
+	dbg("\n");
+	inode->i_private = kmem_alloc( sizeof( struct initrd_file_info ) );
+	inode->size = 0;
+
+	return 0;	
+}
+
+static int unlink(struct inode * inode)
+{
+	struct initrd_file_info  * file_state = PRIV_DATA(inode->i_private);
+
+	dbg("\n");
+
+	kmem_free( inode->i_private );
+	return 0;	
+}
+
+struct inode_operations initrd_iops = {
+	.create = create,	
+	.unlink = unlink,
+};
+
+struct kfs_fops initrd_fops = {
+	.open  = initrd_open,
+	.read  = initrd_read,
+	.lseek = initrd_lseek,
+	.write = initrd_write,
+	.ioctl = initrd_ioctl,
+};
+
+
+
+static inline uint32_t 
+__cpio_hdr_to_u32(uint8_t * val)
+{
+	uint32_t result = 0;
+	int i = 0;
+
+	for (i = 0; i < 8; i++) {
+		uint32_t tmp = isdigit(val[i]) ? val[i] - '0' : tolower(val[i]) - 'a' + 10;
+		result += (tmp << ((7 - i) * 4)); 
+	}
+
+	return result;
+}
+
+
+uint8_t *
+unpack_initrd(paddr_t initrd_start, 
+              paddr_t initrd_end)
+{
+	uint8_t * init_exec_ptr = NULL;
+	paddr_t offset       = 0;
+
+	while (1) {
+
+		struct cpio_header * hdr = __va(initrd_start + offset);
+		
+		char    * file_name = NULL;
+		uint8_t * file_data = NULL;
+
+		uint32_t name_size  = 0;
+		uint32_t data_size  = 0;
+		uint32_t file_mode  = 0;
+
+
+		if (initrd_start + offset >= initrd_end) {
+			// End of archive
+			break;
+		}
+
+
+		if (memcmp(hdr->c_magic, cpio_magic_newc, sizeof(cpio_magic_newc)) != 0) {
+			printk("Error: Invalid CPIO Archive\n");
+			return NULL;
+		}
+
+		name_size = __cpio_hdr_to_u32(hdr->c_namesize);
+		data_size = __cpio_hdr_to_u32(hdr->c_filesize);
+		file_mode = __cpio_hdr_to_u32(hdr->c_mode);
+
+		file_name = __va(initrd_start + offset + sizeof(struct cpio_header));
+		file_data = __va(ALIGN(initrd_start + offset + sizeof(struct cpio_header) + name_size, 4));
+
+
+		// printk("CPIO File: %s [size=%d] [mode=%x]\n", file_name, data_size, file_mode);
+
+		if (name_size == 0) {
+			printk("CPIO Error: Invalid name length\n");
+			return NULL;
+		}
+
+		if (strncmp(file_name, "TRAILER!!!", strlen(file_name)) == 0) {
+			// end of archive
+			break;
+		}
+
+
+		if (S_ISDIR(file_mode)) {
+			kfs_mkdir(file_name, file_mode);
+		} else if (S_ISREG(file_mode)) {
+			struct initrd_file_info * file_info  = kmem_alloc(sizeof(struct initrd_file_info));
+			struct inode            * file_inode = NULL;
+			file_info->data = file_data;
+
+			file_inode = kfs_create(file_name, &initrd_iops, &initrd_fops, file_mode, file_info, sizeof(struct initrd_file_info));
+			file_inode->size = data_size;
+
+			//printk("%s\n", file_name);
+
+			if (strncmp(file_name, "init", strlen(file_name)) == 0) {
+				printk("Found init\n");
+				init_exec_ptr = file_data;
+			}
+
+		} else if (S_ISLNK(file_mode)) {
+			//printk("Symlinks not yet supported\n");
+		} else {
+			printk("Error: INITRD file type (%o) not supported\n", file_mode & S_IFMT);
+		}
+
+		offset += sizeof(struct cpio_header);
+		offset += name_size;
+		offset  = ALIGN(offset, 4);
+		offset += data_size;
+		offset  = ALIGN(offset, 4);
+	}
+
+	return init_exec_ptr;
+}

--- a/kernel/kfs.c
+++ b/kernel/kfs.c
@@ -531,6 +531,7 @@ kfs_create_at(struct inode                  * root_inode,
 		//	__func__, full_filename );
 		//return NULL;
 		root_inode = kfs_root;
+		filename   = full_filename;
 	}else{
 		filename++;
 	}

--- a/kernel/linux_syscalls/Makefile
+++ b/kernel/linux_syscalls/Makefile
@@ -58,6 +58,7 @@ obj-y := \
 	pipe2.o  \
 	stat.o	 \
 	fstat.o	 \
+	newfstatat.o \
 	getdents.o \
 	getdents64.o \
 	readlink.o \

--- a/kernel/linux_syscalls/newfstatat.c
+++ b/kernel/linux_syscalls/newfstatat.c
@@ -1,0 +1,58 @@
+#include <lwk/kfs.h>
+#include <arch/uaccess.h>
+#include <arch-generic/fcntl.h>
+
+
+int
+newfstatat(int       fd,
+           uaddr_t   u_pathname, 
+           uaddr_t   u_buf,
+           int       flags)
+{
+	char pathname[ MAX_PATHLEN ];
+	struct inode * root_inode = NULL;
+	struct inode * inode = NULL;
+
+	int ret = -EBADF;
+
+	if( strncpy_from_user( pathname, (void*) u_pathname, sizeof(pathname) ) < 0 ) {
+		printk("bad copy from user\n");
+
+		return -EFAULT;
+	}
+
+	if ((pathname[0] == '/') ||
+	    (fd          == AT_FDCWD)) {
+		root_inode = kfs_root;
+	} else {
+		struct file * root_file = get_current_file(fd);
+		
+		if (!root_file) {
+			return -EBADF;
+		}
+
+		root_inode = root_file->inode;
+	}
+
+__lock(&_lock);
+	
+	if (strlen(pathname) != 0) {
+		inode = kfs_lookup(root_inode, pathname, 0);
+	} else if (flags & AT_EMPTY_PATH) {
+		inode = root_inode;
+	} else {
+		ret = -ENOENT;
+		goto out;
+	}
+
+	if (inode == NULL) {
+		printk(KERN_WARNING
+		"Attempting fstat() on fd %d with no backing inode.\n", fd);
+	}
+
+	ret = kfs_stat(inode, u_buf);
+out:
+__unlock(&_lock);
+	return ret;
+
+}

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -228,6 +228,9 @@ start_kernel()
 	/*
 	 * Start up user-space...
 	 */
+
+    setup_userspace(initrd_start, initrd_end);
+
 	printk(KERN_INFO "Loading initial user-level task (init_task)...\n");
 	if ((status = create_init_task()) != 0)
 		panic("Failed to create init_task (status=%d).", status);


### PR DESCRIPTION
This adds support for specifying CPIO archives as the initrd image along with the previous approach of specifying an elf image.